### PR TITLE
Create privacy attribute for groups

### DIFF
--- a/src/controllers/group/groupService.js
+++ b/src/controllers/group/groupService.js
@@ -10,17 +10,16 @@ const createGroup = async (groupDetails) => {
 };
 
 const getGroups = async () => {
-  const groups = await Group.findSearchableGroups();
+  const groups = await Group.findPublicGroups();
   return groups;
 };
 
 
 const addUserToGroup = async (joinRequest) => {
-  // implement check to see if the group is a private group or not
   try {
     const { groupId, user } = joinRequest;
 
-    const updatedGroup = await Group.findOneAndUpdate({ _id: groupId, 'members.email': { $ne: user.email } }, { $push: { members: user } });
+    const updatedGroup = await Group.findOneAndUpdate({ _id: groupId, public: true, 'members.email': { $ne: user.email } }, { $push: { members: user } });
 
     if (updatedGroup) {
       const { name, description, savingsAmount } = updatedGroup;

--- a/src/controllers/group/models/Group.js
+++ b/src/controllers/group/models/Group.js
@@ -15,7 +15,7 @@ const groupSchema = new mongoose.Schema({
     type: Number,
     required: 'Please enter the maximum number of group members',
   },
-  isSearchable: { // change this to public or private
+  public: {
     type: Boolean,
     default: true,
   },
@@ -34,8 +34,8 @@ const groupSchema = new mongoose.Schema({
   members: [{}],
 });
 
-groupSchema.statics.findSearchableGroups = async function () {
-  const searchableGroups = await this.find({ isSearchable: true });
+groupSchema.statics.findPublicGroups = async function () {
+  const searchableGroups = await this.find({ public: true });
   return searchableGroups;
 };
 export default mongoose.model('Group', groupSchema);


### PR DESCRIPTION
This feature does the following:
- Changes the attribute isSearchable to Public
- Changes the name of the static method findSearchableGroup to findPublicGroups
- allows users to only join public groups.