### PR TITLE
Create group search functionality

### DIFF
--- a/src/controllers/group/groupRouter.js
+++ b/src/controllers/group/groupRouter.js
@@ -12,6 +12,13 @@ groupRouter.get('/', asyncHandler(async (req, res) => {
   res.status(200).send(groups);
 }));
 
+groupRouter.get('/search',
+  validate(validationRules.searchTerm, { statusCode: 422, keyByField: true }, {}),
+  asyncHandler(async (req, res) => {
+    const searchResult = await groupService.searchGroups(req.query.searchTerm);
+    res.status(200).send(searchResult);
+  }));
+
 groupRouter.use(asyncHandler(async (req, res, next) => {
   const token = req.headers.authorization;
   const payload = await authService.verifyLogin(token);

--- a/src/controllers/group/groupService.js
+++ b/src/controllers/group/groupService.js
@@ -37,4 +37,24 @@ const addUserToGroup = async (joinRequest) => {
   }
 };
 
-export default { createGroup, getGroups, addUserToGroup };
+const searchGroups = async (searchString) => {
+  const searchResult = await Group.find({
+    public: true,
+    $text: { $search: searchString },
+  }, {
+    score: { $meta: 'textScore' },
+  })
+    .select({
+      _id: 0, name: 1, description: 1, savingsAmount: 1,
+    })
+    .sort({
+      score: { $meta: 'textScore' },
+    })
+    .limit(5);
+
+  return (searchResult.length ? searchResult : 'Sorry, we could not find what you were looking for');
+
+}
+export default {
+  createGroup, getGroups, addUserToGroup, searchGroups,
+};

--- a/src/controllers/group/models/Group.js
+++ b/src/controllers/group/models/Group.js
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 
+
 const groupSchema = new mongoose.Schema({
   name: {
     type: String,
@@ -32,6 +33,11 @@ const groupSchema = new mongoose.Schema({
     required: 'Please enter admin id',
   },
   members: [{}],
+});
+
+groupSchema.index({
+  name: 'text',
+  description: 'text',
 });
 
 groupSchema.statics.findPublicGroups = async function () {

--- a/src/controllers/group/validationRules.js
+++ b/src/controllers/group/validationRules.js
@@ -16,5 +16,11 @@ const groupId = {
   }),
 };
 
+const searchTerm = {
+  query: Joi.object({
+    searchTerm: Joi.string().trim().required(),
+  }),
+};
+
 // change groupcreation to a better name
-export default { groupCreation, groupId };
+export default { groupCreation, groupId, searchTerm };


### PR DESCRIPTION
The feature gives a user the ability to search for public groups. It does this by performing the following

- Update the Group model to include an index for group name and description
- Create Route for searching groups
- Validates a given search-term to ensure that it exists and is a string
- Provides a handler that queries the model for all public groups with that search-term