### PR TITLE
Setup only admin duties

### DIFF
--- a/src/controllers/group/groupRouter.js
+++ b/src/controllers/group/groupRouter.js
@@ -82,6 +82,12 @@ groupRouter.post('/',
 
 groupRouter.post('/:groupId/invite',
   validate(validationRules.groupInvitation, { statusCode: 422, keyByField: true }, {}),
+  asyncHandler(async (req, res, next) => {
+    const { groupId } = req.params;
+    const { user } = req;
+    await authorizationService.checkIfCurrentUserIsGroupAdmin(groupId, user);
+    next();
+  }),
   asyncHandler(async (req, res) => {
     const { invitees } = req.body;
     const { groupId } = req.params;

--- a/src/controllers/group/groupRouter.js
+++ b/src/controllers/group/groupRouter.js
@@ -5,6 +5,7 @@ import groupService from './groupService';
 import tenureService from './tenureService';
 import validationRules from './validationRules';
 import authService from '../auth/authService';
+import authorizationService from '../../services/authorization';
 import agenda from '../../jobs/agenda';
 
 
@@ -101,6 +102,12 @@ groupRouter.post('/:groupId/join',
 
 groupRouter.post('/:groupId/tenure',
   validate(validationRules.groupId, { statusCode: 422, keyByField: true }, {}),
+  asyncHandler(async (req, res, next) => {
+    const { groupId } = req.params;
+    const { user } = req;
+    await authorizationService.checkIfCurrentUserIsGroupAdmin(groupId, user);
+    next();
+  }),
   asyncHandler(async (req, res) => {
     const { groupId } = req.params;
     const { cadance } = req.body;

--- a/src/services/authorization.js
+++ b/src/services/authorization.js
@@ -1,0 +1,17 @@
+import createError from 'http-errors';
+import Group from '../controllers/group/models/Group';
+
+const checkIfCurrentUserIsGroupAdmin = async (groupId, currentUser) => {
+  const group = await Group.findById(groupId, 'admin', { lean: true });
+  console.log(group);
+  const groupAdmin = group.admin;
+  if (groupAdmin.email !== currentUser.email) {
+    const message = 'You need to be the admin of this group to perform this action';
+    throw createError(400, message);
+  }
+  return true;
+};
+
+export default {
+  checkIfCurrentUserIsGroupAdmin,
+};

--- a/src/services/authorization.js
+++ b/src/services/authorization.js
@@ -3,7 +3,6 @@ import Group from '../controllers/group/models/Group';
 
 const checkIfCurrentUserIsGroupAdmin = async (groupId, currentUser) => {
   const group = await Group.findById(groupId, 'admin', { lean: true });
-  console.log(group);
   const groupAdmin = group.admin;
   if (groupAdmin.email !== currentUser.email) {
     const message = 'You need to be the admin of this group to perform this action';


### PR DESCRIPTION
The feature ensures that only admins can do the following:

- Invite users to a private group
- start savings tenure for a group